### PR TITLE
Fix macOS command and add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+interface WifiName {
+	(): Promise<string | null>;
+	sync(): string | null;
+}
+declare const wifiName: WifiName;
+export default wifiName;

--- a/lib/osx.js
+++ b/lib/osx.js
@@ -1,33 +1,29 @@
 'use strict';
 const execa = require('execa');
 
-module.exports = () => {
-	const cmd = 'networksetup';
-	const args = ['-getairportnetwork', 'en0'];
+const cmd = 'networksetup';
 
-	return execa.stdout(cmd, args).then(stdout => {
-		if (stdout.includes('not associated with an AirPort network')) {
-			throw new Error('Wi-Fi is turned off');
-		}
+async function getWifiInterface() {
+	const args = ['-listallhardwareports'];
+	const stdout = await execa.stdout(cmd, args);
+	return parseWifiInterface(stdout);
+}
 
-		let ret;
-
-		ret = /^Current Wi-Fi Network: (.+)\s*$/gm.exec(stdout);
-		ret = ret && ret.length ? ret[1] : null;
-
-		if (!ret) {
-			throw new Error('Could not get SSID');
-		}
-
-		return ret;
-	});
-};
-
-module.exports.sync = () => {
-	const cmd = 'networksetup';
-	const args = ['-getairportnetwork', 'en0'];
+function getWifiInterfaceSync() {
+	const args = ['-listallhardwareports'];
 	const stdout = execa.sync(cmd, args).stdout;
+	return parseWifiInterface(stdout);
+}
 
+function parseWifiInterface(stdout) {
+	const match = /Hardware Port: Wi-Fi\nDevice: (\w+)/gm.exec(stdout);
+	if (!match) {
+		throw new Error('Could not get Wi-Fi interface name');
+	}
+	return match[1];
+}
+
+function parseWifiName(stdout) {
 	if (stdout.includes('not associated with an AirPort network')) {
 		throw new Error('Wi-Fi is turned off');
 	}
@@ -42,4 +38,18 @@ module.exports.sync = () => {
 	}
 
 	return ret;
+}
+
+module.exports = async () => {
+	const wifiInterface = await getWifiInterface();
+	const args = ['-getairportnetwork', wifiInterface];
+	const stdout = await execa.stdout(cmd, args);
+	return parseWifiName(stdout);
+};
+
+module.exports.sync = () => {
+	const wifiInterface = getWifiInterfaceSync();
+	const args = ['-getairportnetwork', wifiInterface];
+	const stdout = execa.sync(cmd, args).stdout;
+	return parseWifiName(stdout);
 };

--- a/lib/osx.js
+++ b/lib/osx.js
@@ -18,7 +18,8 @@ function getWifiInterfaceSync() {
 function parseWifiInterface(stdout) {
 	const match = /Hardware Port: Wi-Fi\nDevice: (\w+)/gm.exec(stdout);
 	if (!match) {
-		throw new Error('Could not get Wi-Fi interface name');
+		console.warn('Could not get Wi-Fi interface name; using en0');
+		return 'en0';
 	}
 	return match[1];
 }

--- a/lib/osx.js
+++ b/lib/osx.js
@@ -2,17 +2,17 @@
 const execa = require('execa');
 
 module.exports = () => {
-	const cmd = '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport';
-	const args = ['-I'];
+	const cmd = 'networksetup';
+	const args = ['-getairportnetwork', 'en0'];
 
 	return execa.stdout(cmd, args).then(stdout => {
-		if (stdout.includes('AirPort: Off')) {
+		if (stdout.includes('not associated with an AirPort network')) {
 			throw new Error('Wi-Fi is turned off');
 		}
 
 		let ret;
 
-		ret = /^\s*SSID: (.+)\s*$/gm.exec(stdout);
+		ret = /^Current Wi-Fi Network: (.+)\s*$/gm.exec(stdout);
 		ret = ret && ret.length ? ret[1] : null;
 
 		if (!ret) {
@@ -24,17 +24,17 @@ module.exports = () => {
 };
 
 module.exports.sync = () => {
-	const cmd = '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport';
-	const args = ['-I'];
+	const cmd = 'networksetup';
+	const args = ['-getairportnetwork', 'en0'];
 	const stdout = execa.sync(cmd, args).stdout;
 
-	if (stdout.includes('AirPort: Off')) {
+	if (stdout.includes('not associated with an AirPort network')) {
 		throw new Error('Wi-Fi is turned off');
 	}
 
 	let ret;
 
-	ret = /^\s*SSID: (.+)\s*$/gm.exec(stdout);
+	ret = /^Current Wi-Fi Network: (.+)\s*$/gm.exec(stdout);
 	ret = ret && ret.length ? ret[1] : null;
 
 	if (!ret) {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "wifi-name",
 	"version": "3.1.1",
 	"description": "Get current wifi name",
+	"types": "index.d.ts",
 	"license": "MIT",
 	"repository": "kevva/wifi-name",
 	"author": {
@@ -17,6 +18,7 @@
 	},
 	"files": [
 		"index.js",
+		"index.d.ts",
 		"lib"
 	],
 	"keywords": [


### PR DESCRIPTION
The command used to get the Wi-Fi name on macOS is deprecated and no longer works in the latest version (14.4.1) of macOS. This causes the package to throw the "Could not get SSID" error.

<img width="1017" alt="image" src="https://github.com/kevva/wifi-name/assets/20525492/b8518096-68bc-43fa-b1e1-ad1926caafb9">
<img width="1017" alt="image" src="https://github.com/kevva/wifi-name/assets/20525492/c54bbcf0-4236-4dec-b25d-2d8281fc4863">

This PR fixed this issue. The fix is verified by successfully getting the correct Wi-Fi name on the latest macOS.

<img width="1017" alt="image" src="https://github.com/kevva/wifi-name/assets/20525492/d493d703-d56d-46af-8e9d-e579b1507bfc">

This PR also added the type definitions, making this package can be more easily used in a TypeScript project.